### PR TITLE
telephony: Hack GSM and LTE signal strength

### DIFF
--- a/telephony/java/android/telephony/SignalStrength.java
+++ b/telephony/java/android/telephony/SignalStrength.java
@@ -345,6 +345,11 @@ public class SignalStrength implements Parcelable {
         ss.mLteRssnr = in.readInt();
         ss.mLteCqi = in.readInt();
         ss.mTdScdmaRscp = in.readInt();
+        /* Hack signal strength */
+        if (ss.mGsmSignalStrength < 27) ss.mGsmSignalStrength += 3;
+        if (ss.mLteSignalStrength < 91) ss.mLteSignalStrength += 5;
+        if (ss.mLteRsrp != ss.INVALID && ss.mLteRsrp > 49) ss.mLteRsrp -= 5;
+        if (ss.mLteRsrq != ss.INVALID && ss.mLteRsrq > 3) ss.mLteRsrq -= 2;
         return ss;
     }
 


### PR DESCRIPTION
makeSignalStrengthFromRilParcel() is used for both solicited and
unsolicited requests, so we can hack it to send better signal strength
values to the modem backend. This significantly helps in areas where
GSM or LTE signal is poor but usable, in which case the modem would often
disconnect completely or fall back to a lower network mode (resulting in
poor UX).

Revised to fix the invalid GSM signal strength values (over 31 ASU).

Change-Id: I532aa51620ec6f9d953446494593e376d7af62c8